### PR TITLE
Don't lose the query string when parsing URLs

### DIFF
--- a/src/clj_dbcp/core.clj
+++ b/src/clj_dbcp/core.clj
@@ -147,11 +147,13 @@
             port (let [p (.getPort ^URI jdbc-uri)]
                    (and (pos? p) p))
             path (.getPath ^URI jdbc-uri)
+            query (.getRawQuery ^URI jdbc-uri)
             scheme  (.getScheme ^URI jdbc-uri)
             adapter (subproto-map scheme scheme)]
         (merge {:adapter  (keyword adapter)
                 :jdbc-url (str "jdbc:" adapter "://" host
-                               (when port ":") (or port "") path)}
+                               (when port ":") (or port "") path
+                               (when query "?") (or query ""))}
                (if-let [user-info (.getUserInfo ^URI jdbc-uri)]
                  (let [[un pw] (str/split user-info #":")]
                    {:username un


### PR DESCRIPTION
eg. Heroku Postgres requires `?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory` in the URL when you're accessing it from outside the Heroku network. clj-dbcp should pass the parameter to the JDBC URL.
